### PR TITLE
feat: set debug mode on demand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/nats-io/nats.go v1.39.1
-	github.com/open-uem/nats v0.0.0-20250319091503-aed56409cb42
+	github.com/open-uem/nats v0.0.0-20250324100902-e34b427bb2cf
 	github.com/open-uem/utils v0.0.0-20250105115248-b0599a18d2b5
 	github.com/open-uem/wingetcfg v0.0.0-20250317130843-80896d796f35
 	github.com/pkg/sftp v1.13.6

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,10 @@ github.com/open-uem/nats v0.0.0-20250318092406-dff5c2adace7 h1:jlmTfzWUnbkITUtp/
 github.com/open-uem/nats v0.0.0-20250318092406-dff5c2adace7/go.mod h1:uE6mXBorzBYaj5lIkK4Jrtr/U1H5j4lZ/szTaxAnQHo=
 github.com/open-uem/nats v0.0.0-20250319091503-aed56409cb42 h1:xThlehve6Jmx8SUcgIE0dWYE+kvls+RTZldoHKDOvV8=
 github.com/open-uem/nats v0.0.0-20250319091503-aed56409cb42/go.mod h1:uE6mXBorzBYaj5lIkK4Jrtr/U1H5j4lZ/szTaxAnQHo=
+github.com/open-uem/nats v0.0.0-20250324080214-a47b0d0b44be h1:6cDhvRdJ/gZVHbLyuzC15F7PKyanZKRQdTXJrEyvtSs=
+github.com/open-uem/nats v0.0.0-20250324080214-a47b0d0b44be/go.mod h1:uE6mXBorzBYaj5lIkK4Jrtr/U1H5j4lZ/szTaxAnQHo=
+github.com/open-uem/nats v0.0.0-20250324100902-e34b427bb2cf h1:WqGppLiQLqq5Wfx44tfSm+xWCK42PXREsJR1XcAhEH8=
+github.com/open-uem/nats v0.0.0-20250324100902-e34b427bb2cf/go.mod h1:uE6mXBorzBYaj5lIkK4Jrtr/U1H5j4lZ/szTaxAnQHo=
 github.com/open-uem/utils v0.0.0-20250105115248-b0599a18d2b5 h1:EsMEGiRRtb0vJCdpczs8YkJIOvUpyxxI1P49AzBn9g4=
 github.com/open-uem/utils v0.0.0-20250105115248-b0599a18d2b5/go.mod h1:R2LdbpDQixQPMa4a6yuZsYFPANQzXU8EPzQD7/1iQXk=
 github.com/open-uem/wingetcfg v0.0.0-20250317130843-80896d796f35 h1:mhyVM3A8JwC2B9g1yYepEi+c2p1Zjk6eYQKn84dHNi8=

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -193,6 +193,7 @@ func (c *Config) WriteConfig() error {
 	cfg.Section("Agent").Key("DefaultFrequency").SetValue(strconv.Itoa(c.DefaultFrequency))
 	cfg.Section("Agent").Key("ExecuteTaskEveryXMinutes").SetValue(strconv.Itoa(c.ExecuteTaskEveryXMinutes))
 	cfg.Section("Agent").Key("WingetConfigureFrequency").SetValue(strconv.Itoa(c.WingetConfigureFrequency))
+	cfg.Section("Agent").Key("Debug").SetValue(strconv.FormatBool(c.Debug))
 
 	if err := cfg.SaveTo(configFile); err != nil {
 		log.Fatalf("[FATAL]: could not save config file, reason: %v", err)

--- a/internal/commands/report/report.go
+++ b/internal/commands/report/report.go
@@ -55,6 +55,7 @@ func RunReport(agentId string, enabled, debug bool, vncProxyPort, sftpPort strin
 	report.VNCProxyPort = vncProxyPort
 	report.CertificateReady = isCertificateReady()
 	report.Enabled = enabled
+	report.DebugMode = debug
 
 	// Check if a restart is still required
 	// Get conf file


### PR DESCRIPTION
Agent debug mode should be set from console on demand. Two new messages (agent.enabledebug and agent.disabledebug) and the respective handlers have been added. Also debug information from the config file is added to agent reports to inform the worker and synchronize the information.

Closes #7 