### PR TITLE
fix: get processor info if more than one windows processor is found

### DIFF
--- a/internal/commands/report/computer_windows.go
+++ b/internal/commands/report/computer_windows.go
@@ -111,7 +111,7 @@ func (r *Report) getProcessorInfo() error {
 		return err
 	}
 
-	if len(processorDst) != 1 {
+	if len(processorDst) < 1 {
 		return fmt.Errorf("got wrong processor result set")
 	}
 


### PR DESCRIPTION
Closes  #35 