### PR TITLE
feat: support neon, improve wayland detection with neon

### DIFF
--- a/internal/commands/remote-desktop/vnc_linux.go
+++ b/internal/commands/remote-desktop/vnc_linux.go
@@ -315,14 +315,18 @@ func IsWaylandDisplayServer() bool {
 
 	// Get XAUTHORITY
 	xauthorityEnv, err := runtime.GetXAuthority(uint32(uid), uint32(gid))
-	if err != nil {
-		log.Printf("[ERROR]: could not check if Wayland as I couldn't get XAUTHORITY env, reason: %v\n", err)
-		return false
+	if err == nil {
+		if strings.Contains(xauthorityEnv, "wayland") {
+			return true
+		}
 	}
 
-	xauthority := strings.TrimPrefix(xauthorityEnv, "XAUTHORITY=")
-	if strings.Contains(xauthority, "wayland") {
-		return true
+	// Get WAYLAND_DISPLAY
+	waylandDisplay, err := runtime.GetWaylandDisplay(uint32(uid), uint32(gid))
+	if err == nil {
+		if strings.Contains(waylandDisplay, "wayland") {
+			return true
+		}
 	}
 
 	return false

--- a/internal/commands/report/applications_linux.go
+++ b/internal/commands/report/applications_linux.go
@@ -26,7 +26,7 @@ func (r *Report) getApplicationsInfo(debug bool) error {
 	}
 
 	switch os {
-	case "debian", "ubuntu", "linuxmint":
+	case "debian", "ubuntu", "linuxmint", "neon":
 		command = `dpkg --search '*.desktop' | awk '{print $1}' | cut -f 1 -d ':'  | sort --unique`
 	case "opensuse-leap":
 		command = `zypper --quiet search -i -f --provides "*.desktop" | awk '{print $3}' | sort --unique`
@@ -47,7 +47,7 @@ func (r *Report) getApplicationsInfo(debug bool) error {
 		if p != "" && strings.TrimSpace(p) != "Name" {
 			app := openuem_nats.Application{}
 			switch os {
-			case "debian", "ubuntu", "linuxmint":
+			case "debian", "ubuntu", "linuxmint", "neon":
 				app.Name, app.Version, app.Publisher = getDpkgInfo(p)
 			case "fedora", "opensuse-leap", "almalinux", "redhat", "rocky":
 				app.Name, app.Version, app.Publisher = getRPMInfo(p)

--- a/internal/commands/report/system_update_linux.go
+++ b/internal/commands/report/system_update_linux.go
@@ -15,7 +15,7 @@ import (
 
 func (r *Report) getSystemUpdateInfo() error {
 	switch r.OS {
-	case "ubuntu", "debian", "linuxmint":
+	case "ubuntu", "debian", "linuxmint", "neon":
 		if err := r.getAptInformation(); err != nil {
 			log.Printf("[ERROR]: could not get pending security updates, reason: %v", err)
 		} else {

--- a/internal/commands/runtime/runtime_linux.go
+++ b/internal/commands/runtime/runtime_linux.go
@@ -227,6 +227,22 @@ func GetXAuthority(uid, gid uint32) (string, error) {
 	return xauthority, nil
 }
 
+// Get WAYLAND_DISPLAY environment variable
+func GetWaylandDisplay(uid, gid uint32) (string, error) {
+	// Ref: https://unix.stackexchange.com/questions/429092/what-is-the-best-way-to-find-the-current-display-and-xauthority-in-non-interacti
+	envCmd := exec.Command("bash", "-c", `ps -u $(id -u) -o pid= | xargs -I{} cat /proc/{}/environ 2>/dev/null | tr '\0' '\n' | grep -m1 '^WAYLAND_DISPLAY='`)
+	envCmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)},
+	}
+	envOut, err := envCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	waylandDisplay := string(envOut)
+
+	return waylandDisplay, nil
+}
+
 // Get DISPLAY environment variable
 func GetDisplay(uid, gid uint32) (string, error) {
 


### PR DESCRIPTION
The agent now supports KDE Neon (which is based on Ubuntu) apps detection, system updates detection...

Closes #111